### PR TITLE
Fix event handler in case no key is specified.

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -13,7 +13,7 @@
 (function(jQuery){
 
 	jQuery.hotkeys = {
-		version: "0.8",
+		version: "0.8+",
 
 		specialKeys: {
 			8: "backspace", 9: "tab", 13: "return", 16: "shift", 17: "ctrl", 18: "alt", 19: "pause",

--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -42,7 +42,7 @@
 			keys = (handleObj.namespace || "").toLowerCase().split(" ");
 
 		//no need to modify handler if no keys specified
-		if (!keys.length) {
+		if (keys.length === 1 && keys[0] === "") {
 			return;
 		}
 


### PR DESCRIPTION
The way it was checking for no keys was wrong since `"".split(" ")` returns
an Array with a single empty string, checking for `keys.length` isn't enough.

Bug was introduced when changed the way plugin works to use namespaces.

I should have tested it earlier, sorry.

This might be related with #23 (never tested it)
