### PR TITLE
Allow for the use of multiple namespaces.

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -40,6 +40,7 @@
 			//will also allow removing listeners of a specific key combination
 			//and support data objects
 			keys = (handleObj.namespace || "").toLowerCase().split(" ");
+			keys = jQuery.map(keys, function(key) { return key.split("."); });
 
 		//no need to modify handler if no keys specified
 		if (keys.length === 1 && keys[0] === "") {


### PR DESCRIPTION
Hotkeys currently expects the key name to be the only namespace on the event and wont work with multiple namespaces. This fixes that and allows for the possibility to bind to multiple key events via multiple namespaces.
