### PR TITLE
Don't side effect jQuery UI autocomplete fields.

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -43,7 +43,7 @@
 			keys = jQuery.map(keys, function(key) { return key.split("."); });
 
 		//no need to modify handler if no keys specified
-		if (keys.length === 1 && keys[0] === "") {
+		if (keys.length === 1 && (keys[0] === "" || keys[0] === "autocomplete")) {
 			return;
 		}
 


### PR DESCRIPTION
Without this check jQuery UI's autocomplete silently fails. The remote datasource is never hit for the autocomplete data.
