### PR TITLE
Event namespace prefix configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ The syntax is as follows:
       this.value = this.value.replace('$', 'EUR');
     });
 
+You can also configure some prefix for your events namespace, to avoid conflicts with other namespaces:
+
+    // Configure the prefix somewhere in your code
+    jQuery.hotkeys.prefix = "hk_";
+
+    // Then bind the hotkey
+    $(document).bind('keydown.hk_ctrl_a', fn);
+
 ## Types
 Supported types are `'keydown'`, `'keyup'` and `'keypress'`
 

--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -53,7 +53,7 @@
 			// Don't fire in text-accepting inputs that we didn't directly bind to
 			// important to note that $.fn.prop is only available on jquery 1.6+
 			if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
-				event.target.type === "text" || $(event.target).prop('contenteditable') == 'true' )) {
+				event.target.type === "text" || jQuery(event.target).prop('contenteditable') == 'true' )) {
 				return;
 			}
 

--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -15,6 +15,8 @@
 	jQuery.hotkeys = {
 		version: "0.8+",
 
+		prefix: "",
+
 		specialKeys: {
 			8: "backspace", 9: "tab", 13: "return", 16: "shift", 17: "ctrl", 18: "alt", 19: "pause",
 			20: "capslock", 27: "esc", 32: "space", 33: "pageup", 34: "pagedown", 35: "end", 36: "home",
@@ -58,7 +60,7 @@
 			// Keypress represents characters, not special keys
 			var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[ event.which ],
 				character = String.fromCharCode( event.which ).toLowerCase(),
-				key, modif = "", possible = {};
+				key, prefix = jQuery.hotkeys.prefix, modif = prefix, possible = {};
 
 			// check combinations (alt|ctrl|shift+anything)
 			if ( event.altKey && special !== "alt" ) {
@@ -92,7 +94,7 @@
 			}
 
 			for ( var i = 0, l = keys.length; i < l; i++ ) {
-				if ( possible[ keys[i] ] ) {
+				if ( possible[ keys[i] ] || ( prefix.length > 0 && keys[i].indexOf( prefix ) != 0 ) ) {
 					return origHandler.apply( this, arguments );
 				}
 			}


### PR DESCRIPTION
Config to allow custom namespace prefixes. This is useful for cases where you still want to bind keyboard events using namespaces, but don't want jquery.hotkeys to interfere in the evaluation. I think issue #26 is related to this problem.
