### PR TITLE
remove whitespaces and unused variable

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -46,10 +46,10 @@
 		//Added keys[0].substring(0, 12) to work with jQuery ui 1.9.0
 		//Added accordion, tabs and menu, then jquery ui can use keys.
 
-			if (keys.length === 1 && (keys[0] === "" || 
-			keys[0].substring(0, 12) === "autocomplete"  || 
-			keys[0].substring(0, 9) === "accordion"  || 
-			keys[0].substring(0, 4) === "tabs"  || 
+			if (keys.length === 1 && (keys[0] === "" ||
+			keys[0].substring(0, 12) === "autocomplete"  ||
+			keys[0].substring(0, 9) === "accordion"  ||
+			keys[0].substring(0, 4) === "tabs"  ||
 			keys[0].substring(0, 4) === "menu")) {
 			return;
 		}
@@ -65,7 +65,7 @@
 			// Keypress represents characters, not special keys
 			var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[ event.which ],
 				character = String.fromCharCode( event.which ).toLowerCase(),
-				key, modif = "", possible = {};
+				modif = "", possible = {};
 
 			// check combinations (alt|ctrl|shift+anything)
 			if ( event.altKey && special !== "alt" ) {


### PR DESCRIPTION
Removed whitespaces and an unused variable named `key`.
