### PR TITLE
Link and attribution correction 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #About
 **jQuery Hotkeys** is a plug-in that lets you easily add and remove handlers for keyboard events anywhere in your code supporting almost any key combination.
 
-This plugin is based off of the plugin by Tzury Bar Yochay: [jQuery.hotkeys](http://github.com/tzuryby/hotkeys)
+It is based on a library [Shortcut.js](http://www.openjs.com/scripts/events/keyboard_shortcuts/shortcut.js) written by [Binny V A](http://www.openjs.com/).
 
 The syntax is as follows:
 

--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -1,11 +1,10 @@
 /*
  * jQuery Hotkeys Plugin
- * Copyright 2010, John Resig
  * Dual licensed under the MIT or GPL Version 2 licenses.
- *
- * Based upon the plugin by Tzury Bar Yochay:
- * http://github.com/tzuryby/hotkeys
- *
+ * 
+ * jQuery plugin by Tzury Bar Yochay
+ * http://github.com/tzuryby/jquery.hotkeys
+ * 
  * Original idea by:
  * Binny V A, http://www.openjs.com/scripts/events/keyboard_shortcuts/
 */


### PR DESCRIPTION
Fix for issue #34  
- When John Resig forked this repo, he added a link in the [Readme](https://github.com/tzuryby/jquery.hotkeys/blob/master/README.md) to acknowledge the original project. Unfortunately, it appears that a [PR he authored was accepted](https://github.com/tzuryby/jquery.hotkeys/commit/2bc49e96bfed711244ceb0fc64b28f2c5b49900c) and this new attribution overwrote the previous acknowledgment of 
  [Shortcut.js](http://www.openjs.com/scripts/events/keyboard_shortcuts/shortcut.js). This returns that acknowledgment.  
- Fixes the invalid link found in the masthead of the [script file](https://github.com/tzuryby/jquery.hotkeys/blob/master/jquery.hotkeys.js) in addition to returning the previously removed acknowledgement of [Shortcut.js](http://www.openjs.com/scripts/events/keyboard_shortcuts/shortcut.js)
