### PR TITLE
Mozilla shortcut hotkeys with keyboard macros (e.g., alt_ctrl_o, alt_ctrl_q) not working

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -30,7 +30,10 @@
 			"`": "~", "1": "!", "2": "@", "3": "#", "4": "$", "5": "%", "6": "^", "7": "&",
 			"8": "*", "9": "(", "0": ")", "-": "_", "=": "+", ";": ": ", "'": "\"", ",": "<",
 			".": ">",  "/": "?",  "\\": "|"
-		}
+		},
+		macros: [
+			"æ","ē","r̥","ṭ","ñ","ū","ī","ō","ā","ś","ḍ","ṅ","ḥ","l̥","ṣ","ṇ","ṁ","₹"
+		]
 	};
 
 	function keyHandler( handleObj ) {
@@ -89,6 +92,9 @@
 				possible[ modif + special ] = true;
 
 			} else {
+				if(modif=="" && jQuery.hotkeys.macros.indexOf(event.key.toLowerCase()) != -1){
+					modif = "alt_ctrl_";
+				}
 				possible[ modif + character ] = true;
 				possible[ modif + jQuery.hotkeys.shiftNums[ character ] ] = true;
 


### PR DESCRIPTION
…ctrl_q) not working

Mozilla shortcut hotkeys with keyboard macros (e.g., alt_ctrl_o, alt_ctrl_q) not working.

Because when pressing

> **_Alt + Ctrl + [any character mapped with macro (q,e,r,t,y,u,i,o,a,d,g,h,l,x,n,m)]_**

it gives

```
event.altKey = false
event.ctrlKey = false
```

which is result gives no mapping to the mentioned hotkey alt_ctlr_o.

Now I have added support for macros in Keyboard EN-US.
Please feel free to add for any macros in your language if any.